### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 ﻿#Captcha PNG generator
 A numeric captcha generator for Node.js
 
-##Features
+## Features
 * Only generate numeric captcha PNG image
 * Build-in fonts
 * Characters up and down, left and right limits, random displacement
 * Full JavaScript
 
-##Examples
+## Examples
 ```javascript
 /**
  * Captcha PNG img generator
@@ -37,4 +37,4 @@ http.createServer(function (request, response) {
 }).listen(8181);
 
 console.log('Web server started.\n http:\\\\127.0.0.1:8181\\captcha.png');
-```
+``


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
